### PR TITLE
feat: 开源 macOS 飞书原生双开 Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 万涂幻象开源工具箱。
 >
-> 含 1 个 Web 应用（祥瑞白板录制工具）+ 13 个 Skill（按领域分 5 类）。
+> 含 1 个 Web 应用（祥瑞白板录制工具）+ 14 个 Skill（按领域分 5 类）。
 
 ---
 
@@ -34,12 +34,13 @@
 vantasma-toolkit/
 ├── apps/
 │   └── whiteboard-recorder/          ← 祥瑞白板录制工具（白板 + 录制 + 摄像头 + 素材库 + 提词器）
-└── skills/                              ← 13 个 Skill，按领域分 5 类
+└── skills/                              ← 14 个 Skill，按领域分 5 类
     ├── 文档自动化/
     │   └── template-fidelity-renderer/  高保真 DOCX 模板填充与验收
     ├── 飞书办公/
     │   ├── feishu-bitable-skill/        飞书多维表格搭建
     │   ├── feishu-bitable-system-prompt/ 多维表格 AI 系统提示词设计
+    │   ├── feishu-multi/                macOS 原生飞书双开
     │   ├── feishu-proposal/             飞书客户方案自动生成
     │   ├── daily-log/                   收工日志 · 飞书全链路足迹聚合
     │   └── group-activity-base/         微信群活跃度 → 飞书多维表格 + 仪表盘
@@ -93,7 +94,7 @@ npm run preview  # 本地预览构建产物
 
 ## 2. Skills
 
-13 个 Skill 按领域分 5 类，分别归在 `skills/<领域>/` 下，可单独取用。
+14 个 Skill 按领域分 5 类，分别归在 `skills/<领域>/` 下，可单独取用。
 
 ### 📄 文档自动化
 
@@ -107,6 +108,7 @@ npm run preview  # 本地预览构建产物
 |---|---|---|
 | `feishu-bitable-skill` | 飞书多维表格搭建（OpenClaw） | [README](skills/飞书办公/feishu-bitable-skill/README.md) |
 | `feishu-bitable-system-prompt` | 飞书多维表格 AI 提示词设计 | [README](skills/飞书办公/feishu-bitable-system-prompt/README.md) |
+| `feishu-multi` | **macOS 原生飞书双开**：两个客户端、两套登录态，支持版本检测、安全重建和独立数据目录，不使用 Lark 或网页版 | [README](skills/飞书办公/feishu-multi/README.md) |
 | `feishu-proposal` | 飞书会议纪要 → 客户方案文档 | [README](skills/飞书办公/feishu-proposal/README.md) |
 | `daily-log` | **收工日志**：一句“收工”→ 飞书全链路足迹自动聚合成带链接、能 @ 人的日报文档（依赖 lark-cli） | [README](skills/飞书办公/daily-log/README.md) |
 | `group-activity-base` | **群活跃度多维表格**：微信群完整历史（谁活跃/谁潜水/进群退群时间/全量发言）→ 飞书三表 + 9 组件仪表盘，支持水位式增量更新（依赖自备 vchat 或兼容的本地微信数据访问工具 + lark-cli；vchat 不在本仓库开源） | [README](skills/飞书办公/group-activity-base/README.md) |

--- a/skills/飞书办公/feishu-multi/LICENSE
+++ b/skills/飞书办公/feishu-multi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 李祥瑞 / 万涂幻象
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/飞书办公/feishu-multi/README.md
+++ b/skills/飞书办公/feishu-multi/README.md
@@ -1,0 +1,175 @@
+# feishu-multi
+
+> 对 AI 说一句“帮我双开飞书”，在 macOS 上同时运行两个原生飞书客户端，分别登录两个账号。
+
+这不是 Lark，也不是网页版，更不需要安装第三方双开器。这个 Skill 会基于你电脑里已经安装的中国版飞书官网客户端，生成一个独立的“飞书双开.app”。
+
+## ✦ 能做什么
+
+- 同时运行官网版飞书和第二个原生飞书
+- 两个客户端使用独立登录态，分别登录不同账号
+- 飞书升级后自动检测版本并安全重建副本
+- 只退出第二个飞书，不影响官网版飞书
+- 检查副本版本、进程、签名和数据目录
+- 重建前归档旧副本，不删除第二账号的数据
+
+## ✦ 它是怎么实现的
+
+飞书 macOS 客户端的 App 包内部仍使用 `Lark.app`、`com.electron.lark` 等技术标识，这不代表安装的是国际版 Lark。
+
+这个 Skill 会：
+
+1. 复制已安装的飞书官网版客户端
+2. 把副本的 Bundle ID 从 `com.electron.lark` 隔离为 `com.electron.lar2`
+3. 把数据目录标识从 `LarkShell` 隔离为 `LarkDual2`
+4. 对修改过的 Mach-O、dylib、Helper、Framework 和主 App 逐层重新签名
+5. 使用 Hardened Runtime 与 Electron 所需的最小 entitlements 启动副本
+
+默认结果：
+
+| 项目 | 位置 |
+|---|---|
+| 官网版飞书 | `/Applications/Lark.app` |
+| 双开副本 | `/Applications/飞书双开.app` |
+| 第二账号数据 | `~/Library/Application Support/LarkDual2` |
+| 旧副本归档 | `~/Applications/Feishu Multi Backups/` |
+
+如果 `/Applications` 不可写，副本会自动安装到 `~/Applications/飞书双开.app`。
+
+## ✦ 环境要求
+
+- macOS
+- 已从飞书官网安装中国版飞书客户端
+- 源 App 的 Bundle ID 为 `com.electron.lark`
+- Claude Code、Codex 或其他支持 Agent Skills 的 AI 编程工具
+
+脚本只调用 macOS 自带的 `codesign`、`ditto`、`PlistBuddy`、`perl` 等工具，没有第三方运行时依赖。
+
+当前已在 Apple Silicon Mac、飞书 `131.0.6778.268` 上完成真实双实例验证。Intel Mac 和未来改变内部结构的飞书版本尚未实测，脚本遇到不兼容结构时会在替换旧副本前停止。
+
+## ✦ 安装
+
+### 让 Agent 自动安装（推荐）
+
+把下面这句话贴给 Codex、Claude Code 或其他支持 Skill 的 Agent：
+
+> **帮我安装 https://github.com/xiangruiai/vantasma-toolkit 里的 feishu-multi skill，路径是 skills/飞书办公/feishu-multi。安装到当前 Agent 的 skills 目录，检查脚本权限并运行 status；确认无误后告诉我重启或开启新对话，再用“帮我双开飞书”触发。**
+
+Codex 也可以使用自带的 `skill-installer` 从 GitHub 路径安装。
+
+### Codex 手动安装
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo xiangruiai/vantasma-toolkit \
+  --path 'skills/飞书办公/feishu-multi'
+```
+
+安装后开启一个新对话，让 Codex 重新发现 Skill。
+
+### Claude Code 手动安装
+
+```bash
+git clone https://github.com/xiangruiai/vantasma-toolkit.git
+cp -R 'vantasma-toolkit/skills/飞书办公/feishu-multi' ~/.claude/skills/
+```
+
+安装后重启 Claude Code。
+
+## ✦ 用法
+
+安装后直接对 Agent 说：
+
+- “帮我双开飞书”
+- “再开一个飞书”
+- “检查飞书双开是否正常”
+- “飞书升级了，重建双开”
+- “退出第二个飞书”
+
+也可以直接运行脚本：
+
+```bash
+bash scripts/feishu-multi.sh auto
+```
+
+| 命令 | 行为 |
+|---|---|
+| `auto` | 自动检查，必要时重建，然后启动两个飞书 |
+| `setup` | 创建副本，但暂不启动 |
+| `start` | 启动官网版和已有副本 |
+| `rebuild` | 归档旧副本，按当前官网版重建并启动 |
+| `status` | 查看版本、PID、签名和数据目录 |
+| `stop` | 只退出第二个飞书 |
+
+查看全部参数：
+
+```bash
+bash scripts/feishu-multi.sh --help
+```
+
+如果官网版飞书不在默认位置：
+
+```bash
+bash scripts/feishu-multi.sh auto --source-app '/自定义路径/Lark.app'
+```
+
+## ✦ 安全设计
+
+- 不修改官网版飞书
+- 不删除聊天记录和登录数据
+- 新副本完整构建并验签后，才替换现有副本
+- 旧副本移动到可恢复的归档目录
+- 拒绝把副本目标设置为官网版飞书本体
+- 新版飞书结构不兼容时提前停止，不盲目替换二进制
+- 不上传账号、聊天记录或任何飞书数据
+
+## ✦ 常见问题
+
+### 为什么源 App 叫 Lark.app？
+
+这是中国版飞书官网客户端在 macOS App 包内使用的文件名和技术标识。脚本会严格校验本地已安装客户端，不会下载或改用国际版 Lark。
+
+### 飞书更新后第二个客户端打不开怎么办？
+
+对 Agent 说“飞书升级了，重建双开”，或者运行：
+
+```bash
+bash scripts/feishu-multi.sh rebuild
+```
+
+第二账号的数据目录不会因为重建 App 而删除。
+
+### 首次打开需要重新登录吗？
+
+第一次创建副本时需要在第二个飞书里登录账号。以后重建会继续复用 `LarkDual2` 数据目录。
+
+### 会不会影响飞书自动更新？
+
+官网版飞书保持原样。官网版更新后，副本不会自动继承新二进制；下次运行 `auto` 时会检测版本差异并重建。
+
+## ✦ 免责声明
+
+本项目与飞书、字节跳动及其关联公司无关，也未获得其授权或背书。飞书、Lark 等名称及商标归各自权利人所有。
+
+客户端升级可能改变内部结构。使用前请确认自己有权在当前设备和账号上运行客户端，一切使用后果由使用者自行承担。
+
+## License
+
+MIT。见 [LICENSE](LICENSE)。
+
+---
+
+## ✦ 关于作者
+
+本 Skill 来自 **万涂幻象多维表格社区**：民间最大的飞书多维表格生态社区，围绕让 AI 真正落地沉淀内容、社区、产品与系统。更多工具与介绍见[仓库主页](../../../README.md)。
+
+| | |
+|---|---|
+| 🌐 个人主页 | https://www.xiangruiai.com |
+| 🏠 社区主页 | https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh |
+| 📚 开源知识库（飞书 Wiki · 311+ 篇） | https://vantasma.feishu.cn/wiki/space/7574356946532925441 |
+| ✉️ 联系 | li@xiangruiai.com |
+
+---
+
+**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)

--- a/skills/飞书办公/feishu-multi/SKILL.md
+++ b/skills/飞书办公/feishu-multi/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: feishu-multi
+description: macOS 原生飞书双开工具。通过复制官网版飞书、隔离 Bundle ID 与 LarkShell 数据目录、恢复 Hardened Runtime 并逐层重签名，创建可同时登录第二个账号的独立飞书客户端。用户要求“飞书双开”“再开一个飞书”“同时打开两个飞书”“修复或重建飞书双开”“检查飞书双开状态”或“退出第二个飞书”时使用；不得用 Lark 或网页版替代。
+---
+
+# 飞书原生双开
+
+在 macOS 上创建并维护一个独立的原生飞书副本。副本拥有不同的 Bundle ID 和用户数据目录，可以和官网版飞书同时运行、分别登录账号。
+
+## 运行入口
+
+使用随 Skill 提供的脚本：
+
+```bash
+bash "<skill目录>/scripts/feishu-multi.sh" <命令>
+```
+
+根据用户意图选择命令：
+
+| 用户意图 | 命令 | 行为 |
+|---|---|---|
+| 双开飞书、再开一个飞书 | `auto` | 检查副本，必要时重建，然后启动两个原生客户端 |
+| 只安装副本，暂不启动 | `setup` | 创建并签名副本 |
+| 启动已有副本 | `start` | 启动原飞书和副本 |
+| 飞书更新后修复、重建 | `rebuild` | 归档旧副本，按当前官网版重建并启动 |
+| 检查是否正常 | `status` | 显示版本、PID、签名和数据目录 |
+| 退出第二个飞书 | `stop` | 只退出副本，不影响原飞书 |
+
+正常请求优先运行：
+
+```bash
+bash "<skill目录>/scripts/feishu-multi.sh" auto
+```
+
+如官网版飞书不在默认位置，显式指定：
+
+```bash
+bash "<skill目录>/scripts/feishu-multi.sh" auto --source-app "/自定义路径/Lark.app"
+```
+
+## 执行流程
+
+1. 若副本可能已经存在，先运行 `status` 获取当前状态。
+2. 普通双开请求运行 `auto`，不要手工复制 App 或自行拼接签名命令。
+3. 脚本完成后，再运行 `status`，确认原飞书和副本都有独立 PID，且副本签名为“通过”。
+4. 向用户报告副本路径、运行状态和独立数据目录。首次打开后的账号登录由用户在飞书界面完成。
+5. 官网版飞书升级后，如果副本版本落后，运行 `rebuild`。
+
+## 默认位置
+
+- 官网版飞书：优先查找 `/Applications/Lark.app`，也兼容 `Feishu.app`、`飞书.app` 和用户应用目录。
+- 双开副本：优先安装到 `/Applications/飞书双开.app`；无写权限时使用 `~/Applications/飞书双开.app`。
+- 独立数据目录：`~/Library/Application Support/LarkDual2`。
+- 旧副本归档：`~/Applications/Feishu Multi Backups/`。
+
+可以用 `--dest-dir`、`--app-name` 和对应的 `FEISHU_MULTI_*` 环境变量覆盖默认值。运行 `--help` 查看完整参数。
+
+## 前提与安全边界
+
+- 仅支持 macOS。
+- 需要已安装飞书官网版客户端，当前支持的源 Bundle ID 为 `com.electron.lark`。这只是飞书官网版在 macOS 包内使用的技术标识，不代表国际版 Lark。
+- 只使用 macOS 自带工具，不安装第三方依赖，不需要另装双开器。
+- 不修改官网版飞书，不删除聊天数据。重建时先完整构建并验签新副本，再归档旧副本。
+- 不删除 `LarkDual2` 数据目录，重建副本后原有第二账号登录态应继续复用。
+- 不使用 `rm -rf`、不绕过脚本的源 App 校验、不把 Lark 或网页版当作替代结果。
+- 若新版飞书内部结构变化，脚本应在替换旧副本前失败。保留完整报错并说明当前版本暂不兼容，不要盲目修改二进制。
+
+## 故障排查
+
+先运行：
+
+```bash
+bash "<skill目录>/scripts/feishu-multi.sh" status
+```
+
+- “未找到官方飞书客户端”：先确认官网版已安装，或使用 `--source-app` 指定真实路径。
+- “不支持的源 App Bundle ID”：不要继续补丁，确认选中的是中国版飞书官网客户端。
+- “副本签名失败”或启动后立即退出：运行 `rebuild` 并保留终端输出；必要时检查 `~/Library/Logs/DiagnosticReports/`。
+- `/Applications` 不可写：脚本会自动回退到 `~/Applications`，也可通过 `--dest-dir` 指定可写目录。
+
+任何修复都必须保持“两个原生飞书客户端、两套独立登录态”这一结果。

--- a/skills/飞书办公/feishu-multi/agents/openai.yaml
+++ b/skills/飞书办公/feishu-multi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "飞书原生双开"
+  short_description: "在 macOS 创建、启动与修复独立的原生飞书副本"
+  default_prompt: "使用 $feishu-multi 在这台 Mac 上创建并启动第二个原生飞书客户端。"

--- a/skills/飞书办公/feishu-multi/assets/runtime-entitlements.plist
+++ b/skills/飞书办公/feishu-multi/assets/runtime-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/skills/飞书办公/feishu-multi/scripts/feishu-multi.sh
+++ b/skills/飞书办公/feishu-multi/scripts/feishu-multi.sh
@@ -1,0 +1,524 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTITLEMENTS_FILE="$SKILL_DIR/assets/runtime-entitlements.plist"
+
+OLD_DATA_TOKEN="LarkShell"
+NEW_DATA_TOKEN="${FEISHU_MULTI_DATA_TOKEN:-LarkDual2}"
+OLD_BUNDLE_PREFIX="com.electron.lark"
+NEW_BUNDLE_PREFIX="${FEISHU_MULTI_BUNDLE_PREFIX:-com.electron.lar2}"
+
+SOURCE_APP="${FEISHU_MULTI_SOURCE_APP:-}"
+DEST_DIR="${FEISHU_MULTI_DEST_DIR:-}"
+APP_NAME="${FEISHU_MULTI_APP_NAME:-飞书双开.app}"
+STABILITY_SECONDS="${FEISHU_MULTI_STABILITY_SECONDS:-40}"
+COMMAND="${1:-auto}"
+
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+log() {
+  printf '[feishu-multi] %s\n' "$*"
+}
+
+warn() {
+  printf '[feishu-multi] 警告: %s\n' "$*" >&2
+}
+
+die() {
+  printf '[feishu-multi] 错误: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+用法: feishu-multi.sh [auto|setup|start|rebuild|status|stop] [选项]
+
+命令:
+  auto      副本不存在或版本过期时自动重建，然后启动两个原生飞书
+  setup     创建副本，不启动；已存在健康的同版本副本时不重建
+  start     启动原飞书和已有副本
+  rebuild   安全归档旧副本，基于当前官方飞书重建并启动
+  status    检查版本、签名、主进程和独立数据目录
+  stop      仅退出副本，不退出原飞书
+
+选项:
+  --source-app PATH       官方飞书 App 路径，默认自动查找 /Applications/Lark.app
+  --dest-dir PATH         副本安装目录，默认优先 /Applications
+  --app-name NAME.app     副本名称，默认 飞书双开.app
+  --stability-seconds N   重建后稳定性验证时长，默认 40 秒
+  -h, --help              显示帮助
+
+环境变量:
+  FEISHU_MULTI_SOURCE_APP
+  FEISHU_MULTI_DEST_DIR
+  FEISHU_MULTI_APP_NAME
+  FEISHU_MULTI_STABILITY_SECONDS
+  FEISHU_MULTI_DATA_TOKEN       必须与 LarkShell 等长（9 个 ASCII 字符）
+  FEISHU_MULTI_BUNDLE_PREFIX    必须与 com.electron.lark 等长
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-app)
+      [[ $# -ge 2 ]] || die '--source-app 缺少路径'
+      SOURCE_APP="$2"
+      shift 2
+      ;;
+    --dest-dir)
+      [[ $# -ge 2 ]] || die '--dest-dir 缺少路径'
+      DEST_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      [[ $# -ge 2 ]] || die '--app-name 缺少名称'
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --stability-seconds)
+      [[ $# -ge 2 ]] || die '--stability-seconds 缺少秒数'
+      STABILITY_SECONDS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "未知选项: $1"
+      ;;
+  esac
+done
+
+case "$COMMAND" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
+require_macos() {
+  [[ "$(/usr/bin/uname -s)" == "Darwin" ]] || die '仅支持 macOS'
+}
+
+require_tools() {
+  local tool
+  for tool in \
+    /usr/bin/codesign \
+    /usr/bin/ditto \
+    /usr/bin/file \
+    /usr/bin/find \
+    /usr/bin/grep \
+    /usr/bin/open \
+    /usr/bin/perl \
+    /usr/bin/pgrep \
+    /usr/bin/xattr \
+    /usr/libexec/PlistBuddy; do
+    [[ -x "$tool" ]] || die "缺少系统工具: $tool"
+  done
+  [[ -f "$ENTITLEMENTS_FILE" ]] || die "缺少 entitlements: $ENTITLEMENTS_FILE"
+  /usr/bin/plutil -lint "$ENTITLEMENTS_FILE" >/dev/null || die 'runtime-entitlements.plist 格式错误'
+}
+
+validate_configuration() {
+  [[ "$APP_NAME" == *.app ]] || die '--app-name 必须以 .app 结尾'
+  [[ "$APP_NAME" != */* ]] || die '--app-name 不能包含路径分隔符'
+  [[ "$STABILITY_SECONDS" =~ ^[0-9]+$ ]] || die '--stability-seconds 必须是非负整数'
+  [[ ${#NEW_DATA_TOKEN} -eq ${#OLD_DATA_TOKEN} ]] || \
+    die "数据目录标识必须与 $OLD_DATA_TOKEN 等长"
+  [[ "$NEW_DATA_TOKEN" =~ ^[A-Za-z0-9]+$ ]] || die '数据目录标识只能使用 ASCII 字母和数字'
+  [[ ${#NEW_BUNDLE_PREFIX} -eq ${#OLD_BUNDLE_PREFIX} ]] || \
+    die "Bundle 前缀必须与 $OLD_BUNDLE_PREFIX 等长"
+  [[ "$NEW_BUNDLE_PREFIX" =~ ^[A-Za-z0-9.]+$ ]] || die 'Bundle 前缀包含不安全字符'
+}
+
+plist_read() {
+  local key="$1"
+  local plist="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null
+}
+
+find_source_app() {
+  local candidate
+  local candidates=(
+    "/Applications/Lark.app"
+    "/Applications/Feishu.app"
+    "/Applications/飞书.app"
+    "$HOME/Applications/Lark.app"
+    "$HOME/Applications/Feishu.app"
+    "$HOME/Applications/飞书.app"
+  )
+
+  if [[ -n "$SOURCE_APP" ]]; then
+    [[ -d "$SOURCE_APP" ]] || die "未找到源 App: $SOURCE_APP"
+    return
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -d "$candidate" ]]; then
+      SOURCE_APP="$candidate"
+      return
+    fi
+  done
+  die '未找到官方飞书客户端，请先从飞书官网安装，或使用 --source-app 指定路径'
+}
+
+validate_source_app() {
+  local source_plist="$SOURCE_APP/Contents/Info.plist"
+  local source_bundle
+  local source_executable
+
+  [[ -f "$source_plist" ]] || die "源 App 缺少 Info.plist: $SOURCE_APP"
+  source_bundle="$(plist_read CFBundleIdentifier "$source_plist" || true)"
+  source_executable="$(plist_read CFBundleExecutable "$source_plist" || true)"
+  [[ "$source_bundle" == "$OLD_BUNDLE_PREFIX" ]] || \
+    die "不支持的源 App Bundle ID: ${source_bundle:-<empty>}（期望 $OLD_BUNDLE_PREFIX）"
+  [[ -n "$source_executable" && -x "$SOURCE_APP/Contents/MacOS/$source_executable" ]] || \
+    die '源 App 主程序不可用'
+}
+
+resolve_destination() {
+  local source_canonical
+  local destination_canonical
+
+  if [[ -z "$DEST_DIR" ]]; then
+    if [[ -e "/Applications/$APP_NAME" || -w "/Applications" ]]; then
+      DEST_DIR="/Applications"
+    else
+      DEST_DIR="$HOME/Applications"
+      warn "/Applications 不可写，将副本安装到 $DEST_DIR"
+    fi
+  fi
+
+  /bin/mkdir -p "$DEST_DIR"
+  [[ -d "$DEST_DIR" && -w "$DEST_DIR" ]] || die "目标目录不可写: $DEST_DIR"
+  DEST_APP="$DEST_DIR/$APP_NAME"
+  source_canonical="$(cd "$(dirname "$SOURCE_APP")" && pwd -P)/$(basename "$SOURCE_APP")"
+  destination_canonical="$(cd "$DEST_DIR" && pwd -P)/$APP_NAME"
+  [[ "$destination_canonical" != "$source_canonical" ]] || \
+    die '副本目标不能与官网版飞书是同一路径'
+  BACKUP_DIR="$HOME/Applications/Feishu Multi Backups"
+  /bin/mkdir -p "$BACKUP_DIR"
+}
+
+app_version() {
+  local app_path="$1"
+  plist_read CFBundleShortVersionString "$app_path/Contents/Info.plist" || true
+}
+
+app_executable_path() {
+  local app_path="$1"
+  local executable
+  executable="$(plist_read CFBundleExecutable "$app_path/Contents/Info.plist" || true)"
+  [[ -n "$executable" ]] || return 1
+  printf '%s/Contents/MacOS/%s\n' "$app_path" "$executable"
+}
+
+pid_for_binary() {
+  local binary_path="$1"
+  local matches
+  matches="$(/usr/bin/pgrep -f -x "$binary_path" 2>/dev/null || true)"
+  printf '%s\n' "$matches" | /usr/bin/sed -n '1p'
+}
+
+pid_for_app() {
+  local app_path="$1"
+  local binary_path
+  binary_path="$(app_executable_path "$app_path" || true)"
+  [[ -n "$binary_path" ]] || return 0
+  pid_for_binary "$binary_path"
+}
+
+stop_clone() {
+  local clone_pid
+  local attempt
+  clone_pid="$(pid_for_app "$DEST_APP")"
+  if [[ -z "$clone_pid" ]]; then
+    log '副本未运行'
+    return
+  fi
+
+  log "正在退出副本 PID $clone_pid"
+  /bin/kill -TERM "$clone_pid"
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if ! /bin/kill -0 "$clone_pid" 2>/dev/null; then
+      log '副本已退出'
+      return
+    fi
+    /bin/sleep 1
+  done
+  die '副本未在 10 秒内退出，为避免破坏数据已停止重建'
+}
+
+patch_info_plists() {
+  local stage_app="$1"
+  local plist
+  local current_id
+  local new_id
+
+  while IFS= read -r -d '' plist; do
+    current_id="$(plist_read CFBundleIdentifier "$plist" || true)"
+    case "$current_id" in
+      "$OLD_BUNDLE_PREFIX"*)
+        new_id="${current_id/$OLD_BUNDLE_PREFIX/$NEW_BUNDLE_PREFIX}"
+        /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $new_id" "$plist"
+        ;;
+    esac
+  done < <(/usr/bin/find "$stage_app/Contents" -type f -name Info.plist -print0)
+
+  /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $NEW_BUNDLE_PREFIX" \
+    "$stage_app/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName ${APP_NAME%.app}" \
+    "$stage_app/Contents/Info.plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLName $NEW_BUNDLE_PREFIX" \
+    "$stage_app/Contents/Info.plist" 2>/dev/null || true
+}
+
+patch_macho_files() {
+  local stage_app="$1"
+  local candidate
+  local file_type
+  local patched_count=0
+  local old_token_found=0
+  PATCHED_MACHOS=()
+
+  while IFS= read -r -d '' candidate; do
+    file_type="$(/usr/bin/file -b "$candidate")"
+    case "$file_type" in
+      *Mach-O*)
+        if /usr/bin/grep -aFq "$OLD_DATA_TOKEN" "$candidate" || \
+           /usr/bin/grep -aFq "$OLD_BUNDLE_PREFIX" "$candidate"; then
+          OLD_TOKEN="$OLD_DATA_TOKEN" NEW_TOKEN="$NEW_DATA_TOKEN" \
+          OLD_PREFIX="$OLD_BUNDLE_PREFIX" NEW_PREFIX="$NEW_BUNDLE_PREFIX" \
+            /usr/bin/perl -pi -e \
+            's/\Q$ENV{OLD_TOKEN}\E/$ENV{NEW_TOKEN}/g; s/\Q$ENV{OLD_PREFIX}\E/$ENV{NEW_PREFIX}/g' \
+            "$candidate"
+          PATCHED_MACHOS[${#PATCHED_MACHOS[@]}]="$candidate"
+          patched_count=$((patched_count + 1))
+        fi
+        ;;
+    esac
+  done < <(/usr/bin/find "$stage_app/Contents" -type f -print0)
+
+  [[ $patched_count -gt 0 ]] || die '未在客户端中找到可补丁的 Mach-O 文件，当前飞书版本可能已改变内部结构'
+
+  for candidate in "${PATCHED_MACHOS[@]}"; do
+    if /usr/bin/grep -aFq "$OLD_DATA_TOKEN" "$candidate" || \
+       /usr/bin/grep -aFq "$OLD_BUNDLE_PREFIX" "$candidate"; then
+      warn "补丁后仍发现旧标识: $candidate"
+      old_token_found=1
+    fi
+  done
+  [[ $old_token_found -eq 0 ]] || die '二进制补丁未完整应用'
+  log "已补丁 $patched_count 个 Mach-O 文件"
+}
+
+sign_clone() {
+  local stage_app="$1"
+  local macho_file
+  local nested_app
+  local framework
+
+  /usr/bin/xattr -dr com.apple.quarantine "$stage_app" 2>/dev/null || true
+
+  for macho_file in "${PATCHED_MACHOS[@]}"; do
+    /usr/bin/codesign --force --sign - --timestamp=none --options runtime "$macho_file"
+  done
+
+  while IFS= read -r -d '' nested_app; do
+    /usr/bin/codesign --force --sign - --timestamp=none --options runtime \
+      --entitlements "$ENTITLEMENTS_FILE" "$nested_app"
+  done < <(/usr/bin/find "$stage_app/Contents" -depth -type d -name '*.app' -print0)
+
+  while IFS= read -r -d '' framework; do
+    /usr/bin/codesign --force --sign - --timestamp=none --options runtime "$framework"
+  done < <(/usr/bin/find "$stage_app/Contents" -depth -type d -name '*.framework' -print0)
+
+  /usr/bin/codesign --force --sign - --timestamp=none --options runtime \
+    --entitlements "$ENTITLEMENTS_FILE" "$stage_app"
+  /usr/bin/codesign --verify --deep --strict --verbose=2 "$stage_app"
+}
+
+archive_existing_clone() {
+  local timestamp
+  local backup_path
+  timestamp="$(/bin/date +%Y%m%d-%H%M%S)"
+  backup_path="$BACKUP_DIR/${APP_NAME%.app}-$timestamp.app"
+  /bin/mv "$DEST_APP" "$backup_path"
+  LAST_BACKUP_PATH="$backup_path"
+  log "旧副本已归档: $backup_path"
+}
+
+build_clone() {
+  local timestamp
+  local stage_app
+  local source_version
+  local stage_version
+  local stage_bundle
+
+  if [[ -d "$DEST_APP" ]]; then
+    stop_clone
+  fi
+
+  timestamp="$(/bin/date +%Y%m%d-%H%M%S)"
+  stage_app="$DEST_DIR/.feishu-multi-build-$timestamp-$$.app"
+  [[ ! -e "$stage_app" ]] || die "临时构建路径已存在: $stage_app"
+  log "复制官方飞书到临时副本: $stage_app"
+  /usr/bin/ditto "$SOURCE_APP" "$stage_app"
+
+  patch_info_plists "$stage_app"
+  patch_macho_files "$stage_app"
+  sign_clone "$stage_app"
+
+  source_version="$(app_version "$SOURCE_APP")"
+  stage_version="$(app_version "$stage_app")"
+  stage_bundle="$(plist_read CFBundleIdentifier "$stage_app/Contents/Info.plist" || true)"
+  [[ "$stage_version" == "$source_version" ]] || die '副本与源 App 版本不一致'
+  [[ "$stage_bundle" == "$NEW_BUNDLE_PREFIX" ]] || die "副本 Bundle ID 校验失败: $stage_bundle"
+
+  LAST_BACKUP_PATH=""
+  if [[ -e "$DEST_APP" ]]; then
+    archive_existing_clone
+  fi
+
+  if ! /bin/mv "$stage_app" "$DEST_APP"; then
+    if [[ -n "$LAST_BACKUP_PATH" && -e "$LAST_BACKUP_PATH" && ! -e "$DEST_APP" ]]; then
+      /bin/mv "$LAST_BACKUP_PATH" "$DEST_APP"
+      warn '新副本安装失败，已恢复旧副本'
+    fi
+    die '无法安装新副本'
+  fi
+
+  /usr/bin/codesign --verify --deep --strict "$DEST_APP"
+  log "副本已安装: $DEST_APP"
+  log "独立数据目录: $HOME/Library/Application Support/$NEW_DATA_TOKEN"
+}
+
+clone_is_current_and_valid() {
+  local source_version
+  local clone_version
+  local clone_bundle
+  [[ -d "$DEST_APP" ]] || return 1
+
+  source_version="$(app_version "$SOURCE_APP")"
+  clone_version="$(app_version "$DEST_APP")"
+  clone_bundle="$(plist_read CFBundleIdentifier "$DEST_APP/Contents/Info.plist" || true)"
+  [[ "$source_version" == "$clone_version" ]] || return 1
+  [[ "$clone_bundle" == "$NEW_BUNDLE_PREFIX" ]] || return 1
+  /usr/bin/codesign --verify --deep --strict "$DEST_APP" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+start_apps() {
+  local verify_seconds="$1"
+  local clone_binary
+  local clone_pid=""
+  local attempt
+
+  [[ -d "$DEST_APP" ]] || die '副本不存在，请先运行 auto 或 setup'
+  /usr/bin/open "$SOURCE_APP"
+  /usr/bin/open -n "$DEST_APP"
+
+  clone_binary="$(app_executable_path "$DEST_APP")"
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    clone_pid="$(pid_for_binary "$clone_binary")"
+    [[ -n "$clone_pid" ]] && break
+    /bin/sleep 1
+  done
+  [[ -n "$clone_pid" ]] || die '副本主进程未启动'
+
+  if [[ "$verify_seconds" -gt 0 ]]; then
+    log "正在验证副本稳定性（${verify_seconds} 秒）..."
+    /bin/sleep "$verify_seconds"
+    /bin/kill -0 "$clone_pid" 2>/dev/null || \
+      die '副本在稳定性验证期内退出，请查看 ~/Library/Logs/DiagnosticReports 中的 Feishu/Lark Helper 报告'
+  fi
+  log "原生飞书双开成功，副本 PID: $clone_pid"
+}
+
+show_status() {
+  local source_pid
+  local clone_pid
+  local source_binary
+  local clone_binary=""
+  local signature_status='不存在'
+
+  source_binary="$(app_executable_path "$SOURCE_APP")"
+  source_pid="$(pid_for_binary "$source_binary")"
+  if [[ -d "$DEST_APP" ]]; then
+    clone_binary="$(app_executable_path "$DEST_APP" || true)"
+    clone_pid="$(pid_for_binary "$clone_binary")"
+    if /usr/bin/codesign --verify --deep --strict "$DEST_APP" >/dev/null 2>&1; then
+      signature_status='通过'
+    else
+      signature_status='失败'
+    fi
+  else
+    clone_pid=""
+  fi
+
+  printf '源 App: %s\n' "$SOURCE_APP"
+  printf '源版本: %s\n' "$(app_version "$SOURCE_APP")"
+  printf '源进程: %s\n' "${source_pid:-未运行}"
+  printf '副本: %s\n' "$DEST_APP"
+  printf '副本版本: %s\n' "$([[ -d "$DEST_APP" ]] && app_version "$DEST_APP" || printf '不存在')"
+  printf '副本进程: %s\n' "${clone_pid:-未运行}"
+  printf '副本签名: %s\n' "$signature_status"
+  printf '副本数据: %s\n' "$HOME/Library/Application Support/$NEW_DATA_TOKEN"
+}
+
+main() {
+  require_macos
+  require_tools
+  validate_configuration
+  find_source_app
+  validate_source_app
+  resolve_destination
+
+  case "$COMMAND" in
+    auto)
+      if clone_is_current_and_valid; then
+        log '副本已是当前版本且签名有效'
+        start_apps 5
+      else
+        build_clone
+        start_apps "$STABILITY_SECONDS"
+      fi
+      ;;
+    setup)
+      if clone_is_current_and_valid; then
+        log "副本已就绪: $DEST_APP"
+      else
+        build_clone
+      fi
+      ;;
+    start)
+      start_apps 5
+      ;;
+    rebuild)
+      build_clone
+      start_apps "$STABILITY_SECONDS"
+      ;;
+    status)
+      show_status
+      ;;
+    stop)
+      stop_clone
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      usage >&2
+      die "未知命令: $COMMAND"
+      ;;
+  esac
+}
+
+main


### PR DESCRIPTION
## 做了什么

- 新增 `skills/飞书办公/feishu-multi`，支持 `auto/setup/start/rebuild/status/stop`
- 内置等长 Mach-O 补丁、独立 Bundle ID 与 `LarkDual2` 数据目录
- 按 Mach-O、Helper、Framework、主 App 的顺序恢复 Hardened Runtime 签名
- 增加面向使用者的 README、MIT License、安装命令、兼容边界与作者介绍
- 更新工具箱根 README：Skill 数量由 13 调整为 14，并加入飞书办公索引

## 为什么

把已经在真实飞书客户端上验证通过的原生双开方案做成可复用 Skill，让其他 macOS 用户安装后可以直接对 Agent 说“帮我双开飞书”，不使用 Lark 或网页版替代。

## 使用者影响

首次运行会基于本机已安装的中国版飞书创建 `/Applications/飞书双开.app`，并使用 `~/Library/Application Support/LarkDual2` 保存第二账号数据。重建时保留数据并归档旧副本。

## 验证

- `quick_validate.py`：Skill is valid
- `bash -n scripts/feishu-multi.sh`：通过
- `plutil -lint assets/runtime-entitlements.plist`：通过
- 真实 `rebuild`：补丁 15 个 Mach-O，深度签名通过
- 原飞书 PID 1643 与副本 PID 38711 同时运行
- 重建后稳定运行 20 秒，副本有 8 个 Helper 子进程
- 发布目录敏感信息扫描：未发现本机路径、Token、手机号或私钥
- 从公开分支使用 Codex `skill-installer` 下载到全新目录：安装、Skill 校验、脚本语法、plist 和 `status` 全部通过

## 兼容边界

已在 Apple Silicon Mac、飞书 `131.0.6778.268` 实测。Intel Mac 与未来改变内部结构的版本尚未实测；脚本会在替换旧副本前阻断不兼容结构。
