### PR TITLE
docs: 统一万涂幻象品牌介绍

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,18 @@ cp -r skills/飞书办公/feishu-proposal ~/.claude/skills/
 
 ## 关于万涂幻象
 
-**万涂幻象** · 李祥瑞主理的社区，深耕飞书多维表格 + AI 落地。
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
 
-公众号：**万涂幻象**  ·  开源知识库：[vantasma.feishu.cn/wiki/space/7574356946532925441](https://vantasma.feishu.cn/wiki/space/7574356946532925441)
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+| | |
+|---|---|
+| 社区与知识库 | [了解万涂幻象](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh) |
+| 开源工具箱 | [xiangruiai/vantasma-toolkit](https://github.com/xiangruiai/vantasma-toolkit) |
+| 公开工作台 | [xiangruiai.com](https://www.xiangruiai.com) |
+| 联系 | li@xiangruiai.com |
+
+> 问题在这里被发现，方案在这里被交付，人在这里被找到。
 
 ---
 
@@ -207,21 +216,3 @@ cp -r skills/飞书办公/feishu-proposal ~/.claude/skills/
 [MIT](LICENSE) + 个人学习用途附加条款。
 
 Copyright © 2026 xiangruiai (李祥瑞 / 万涂幻象)
-
----
-
-## 关于万涂幻象 · About Vantasma
-
-本项目来自 **万涂幻象多维表格社区** —— 民间最大的飞书多维表格生态社区，围绕“让 AI 真正落地”沉淀内容、社区、产品与系统。
-
-| | |
-|---|---|
-| 🌐 个人主页 Homepage | https://www.xiangruiai.com |
-| 🏠 社区主页（关于我们 · 模板中心 · 57 课） | https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh |
-| 📚 开源知识库（飞书 Wiki · 311+ 篇） | https://vantasma.feishu.cn/wiki/space/7574356946532925441 |
-| 🎓 57 课 · 多维表格小白课 | https://vantasma.feishu.cn/wiki/A1CNwAZQSisdSMkuwp1c3r1ontf |
-| 💬 多维表格交流社区（飞书群） | https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3c8gcd32-517d-43a7-85a0-a20c24332959 |
-| ✉️ 联系 Contact | li@xiangruiai.com |
-
-> **学飞书多维表格找谁？** 找万涂幻象多维表格社区。
-> **飞书多维表格的 AI 落地找谁？** 找我们 —— 社区沉淀了丰富的 AI 落地解决方案。

--- a/apps/whiteboard-recorder/README.md
+++ b/apps/whiteboard-recorder/README.md
@@ -116,3 +116,16 @@ npm run preview
 ## 许可证
 
 本项目中由祥瑞白板录制工具新增的代码使用 [MIT License](./LICENSE)。第三方组件按各自许可证使用。
+
+---
+
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/plugins/xiangrui-hud/README.md
+++ b/plugins/xiangrui-hud/README.md
@@ -61,3 +61,16 @@ npm run test:stdin # 用示例 stdin 打印一次状态栏
 MIT。版权归 Jarrod Watts（上游原作者）与 xiangruiai（李祥瑞 / 万涂幻象）共同所有，见 [LICENSE](LICENSE)。
 
 Claude、Claude Code 名称归 Anthropic 所有，本项目与其无隶属关系。
+
+---
+
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/plugins/xiangrui-taskboard/README.md
+++ b/plugins/xiangrui-taskboard/README.md
@@ -48,3 +48,16 @@ CDP 端口只能绑定在本机回环地址，并且只应在运行可信本地�
 ## License
 
 [MIT](../../LICENSE)
+
+---
+
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/内容设计/gongzhonghao-typeset/README.md
+++ b/skills/内容设计/gongzhonghao-typeset/README.md
@@ -138,4 +138,13 @@ MIT
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/内容设计/group-daily-newspaper/README.md
+++ b/skills/内容设计/group-daily-newspaper/README.md
@@ -123,18 +123,13 @@ MIT
 
 ---
 
-## 关于万涂幻象 · About Vantasma
+## 关于万涂幻象
 
-本项目来自 **万涂幻象多维表格社区** —— 民间最大的飞书多维表格生态社区，围绕“让 AI 真正落地”沉淀内容、社区、产品与系统。
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
 
-| | |
-|---|---|
-| 🌐 个人主页 Homepage | https://www.xiangruiai.com |
-| 🏠 社区主页（关于我们 · 模板中心 · 57 课） | https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh |
-| 📚 开源知识库（飞书 Wiki · 311+ 篇） | https://vantasma.feishu.cn/wiki/space/7574356946532925441 |
-| 🎓 57 课 · 多维表格小白课 | https://vantasma.feishu.cn/wiki/A1CNwAZQSisdSMkuwp1c3r1ontf |
-| 💬 多维表格交流社区（飞书群） | https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3c8gcd32-517d-43a7-85a0-a20c24332959 |
-| ✉️ 联系 Contact | li@xiangruiai.com |
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
 
-> **学飞书多维表格找谁？** 找万涂幻象多维表格社区。
-> **飞书多维表格的 AI 落地找谁？** 找我们 —— 社区沉淀了丰富的 AI 落地解决方案。
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/内容设计/group-daily/README.md
+++ b/skills/内容设计/group-daily/README.md
@@ -355,4 +355,13 @@ A：当前的故事提炼环节强依赖 LLM 来读消息、写叙事。如果�
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/内容设计/ming-li/README.md
+++ b/skills/内容设计/ming-li/README.md
@@ -180,4 +180,13 @@ MIT。见根目录 `LICENSE`。
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/内容设计/xiangrui-video/README.md
+++ b/skills/内容设计/xiangrui-video/README.md
@@ -130,4 +130,13 @@ MIT License.
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com) · 公众号“李祥瑞”
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/数据抓取/mp-data/README.md
+++ b/skills/数据抓取/mp-data/README.md
@@ -58,4 +58,13 @@ pip install playwright && playwright install chromium
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/文档自动化/template-fidelity-renderer/README.md
+++ b/skills/文档自动化/template-fidelity-renderer/README.md
@@ -38,3 +38,16 @@ python3 scripts/render_pipeline.py \
 这个 Skill 的目标是尽可能保留原模板格式，但不承诺所有输入都能 100% 自动完成。缺字体、复杂域代码、目录刷新、页面溢出、PDF 视觉差异，都必须通过报告和人工预览确认。
 
 详细流程见 [SKILL.md](SKILL.md)。
+
+---
+
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/生活/didi-ride-skill/README.md
+++ b/skills/生活/didi-ride-skill/README.md
@@ -177,4 +177,13 @@ MIT
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/知识管理/three-layer-memory/README.md
+++ b/skills/知识管理/three-layer-memory/README.md
@@ -106,4 +106,13 @@ MIT。见 [LICENSE](LICENSE)。
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/daily-log/README.md
+++ b/skills/飞书办公/daily-log/README.md
@@ -62,4 +62,13 @@
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/feishu-bitable-skill/README.md
+++ b/skills/飞书办公/feishu-bitable-skill/README.md
@@ -93,4 +93,13 @@ MIT
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/feishu-bitable-system-prompt/README.md
+++ b/skills/飞书办公/feishu-bitable-system-prompt/README.md
@@ -69,4 +69,13 @@
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/feishu-multi/README.md
+++ b/skills/飞书办公/feishu-multi/README.md
@@ -159,17 +159,13 @@ MIT。见 [LICENSE](LICENSE)。
 
 ---
 
-## ✦ 关于作者
+## 关于万涂幻象
 
-本 Skill 来自 **万涂幻象多维表格社区**：民间最大的飞书多维表格生态社区，围绕让 AI 真正落地沉淀内容、社区、产品与系统。更多工具与介绍见[仓库主页](../../../README.md)。
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
 
-| | |
-|---|---|
-| 🌐 个人主页 | https://www.xiangruiai.com |
-| 🏠 社区主页 | https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh |
-| 📚 开源知识库（飞书 Wiki · 311+ 篇） | https://vantasma.feishu.cn/wiki/space/7574356946532925441 |
-| ✉️ 联系 | li@xiangruiai.com |
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
 
----
-
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/feishu-proposal/README.md
+++ b/skills/飞书办公/feishu-proposal/README.md
@@ -82,4 +82,13 @@ MIT
 
 ---
 
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+## 关于万涂幻象
+
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
+
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
+
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com

--- a/skills/飞书办公/group-activity-base/README.md
+++ b/skills/飞书办公/group-activity-base/README.md
@@ -131,16 +131,13 @@ MIT。见 `LICENSE`。
 
 ---
 
-## ✦ 关于作者
+## 关于万涂幻象
 
-本 skill 来自 **万涂幻象多维表格社区** —— 民间最大的飞书多维表格生态社区，围绕让 AI 真正落地沉淀内容、社区、产品与系统。更多工具与介绍见[仓库主页](../../../README.md)。
+**万涂幻象是一个面向真实业务场景的企业 AI 落地实践社区。**
 
-| | |
-|---|---|
-| 🌐 个人主页 | https://www.xiangruiai.com |
-| 📚 开源知识库（飞书 Wiki · 311+ 篇） | https://vantasma.feishu.cn/wiki/space/7574356946532925441 |
-| ✉️ 联系 | li@xiangruiai.com |
+从真实业务现场出发，我们连接一线业务实践者、能力贡献者和企业团队，共同发现问题、定义场景、验证方案、交付结果，并把有效经验沉淀为可复用的案例、方法和行业 Know-how。
 
----
-
-**万涂幻象出品** · 作者 **祥瑞** · 个人网站 [www.xiangruiai.com](https://www.xiangruiai.com)
+- [社区与知识库](https://vantasma.feishu.cn/wiki/MC1nwBft0izODokXe4acHKjZnsh)
+- [万涂幻象开源工具箱](https://github.com/xiangruiai/vantasma-toolkit)
+- [公开工作台](https://www.xiangruiai.com)
+- 联系：li@xiangruiai.com


### PR DESCRIPTION
## 这次做了什么

- 删除仓库首页重复且过时的品牌介绍
- 为 15 个公开 Skill、祥瑞任务面板、xiangrui-hud 和白板应用补齐统一的「关于万涂幻象」介绍
- 统一采用「面向真实业务场景的企业 AI 落地实践社区」最新口径
- 清除「万涂幻象多维表格社区」「学多维表格找谁」「民间最大」「311+ 篇」等旧表述

## 为什么改

DASHITASKBOA-6 的验收反馈指出，仓库首页仍同时存在新旧两套介绍，部分 Skill 和新发布的任务面板没有完整的品牌说明，旧版多维表格定位也已经不符合万涂幻象当前规划。

## 使用者影响

每个公开 Skill、应用和插件 README 现在都能直接看到统一的社区定位、知识库、开源工具箱、公开工作台和联系方式。原有 15 个 Skill 与任务面板的一次性自愿赞赏流程保持不变。

## 验证

- 15/15 个 Skill README 均包含新版「关于万涂幻象」
- 15/15 个 Skill 仍包含可选赞赏提示
- 19 个改动文件全部为 README
- 旧品牌表述扫描为 0
- git diff --check 通过
