### PR TITLE
Point DeepSeek Harness desktop to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ npm run preview  # 本地预览构建产物
 
 非官方 macOS 桌面壳，把 DeepSeek Harness 的 Web UI 包成原生窗口，图标使用 DeepSeek 鲸鱼。本目录只放安装包，不放源码。
 
-- 安装包：[DeepSeek-Harness-Desktop-1.1.0-macOS-Apple-Silicon.dmg](https://github.com/xiangruiai/deepseek-harness-desktop/releases/download/v1.1.0/DeepSeek-Harness-Desktop-1.1.0-macOS-Apple-Silicon.dmg)
+- 安装包：[DeepSeek-Harness-Desktop-1.2.0-macOS-Apple-Silicon.dmg](https://github.com/xiangruiai/deepseek-harness-desktop/releases/download/v1.2.0/DeepSeek-Harness-Desktop-1.2.0-macOS-Apple-Silicon.dmg)
 - 说明：[`apps/deepseek-harness-desktop/README.md`](apps/deepseek-harness-desktop/README.md)
 - 发布页：[xiangruiai/deepseek-harness-desktop](https://github.com/xiangruiai/deepseek-harness-desktop/releases)
 

--- a/apps/deepseek-harness-desktop/README.md
+++ b/apps/deepseek-harness-desktop/README.md
@@ -6,8 +6,8 @@
 
 ## 下载
 
-- 安装包：https://github.com/xiangruiai/deepseek-harness-desktop/releases/download/v1.1.0/DeepSeek-Harness-Desktop-1.1.0-macOS-Apple-Silicon.dmg
-- 发布页：https://github.com/xiangruiai/deepseek-harness-desktop/releases/tag/v1.1.0
+- 安装包：https://github.com/xiangruiai/deepseek-harness-desktop/releases/download/v1.2.0/DeepSeek-Harness-Desktop-1.2.0-macOS-Apple-Silicon.dmg
+- 发布页：https://github.com/xiangruiai/deepseek-harness-desktop/releases/tag/v1.2.0
 
 ## 安装
 
@@ -16,3 +16,5 @@
 3. 打开应用，在界面里填 API Key。
 
 不需要单独安装 Node.js，也不需要先跑命令行。目前只提供 Apple Silicon。
+
+1.2.0 起支持输入框粘贴、窗口拖动，启动也不会再误开 Finder。


### PR DESCRIPTION
## Summary
- 工具箱下载入口改为 1.2.0 安装包
- 含粘贴、窗口拖动、启动不再误开 Finder
- 仍不把超过 100MB 的 DMG 放进仓库

## Test plan
- [ ] README 链接指向 v1.2.0 Release

Made with [Cursor](https://cursor.com)